### PR TITLE
部门管理新增和编辑弹窗，增加部门负责人下拉选择

### DIFF
--- a/fancyx-server/Fancyx.Admin/Controllers/Organization/EmployeeController.cs
+++ b/fancyx-server/Fancyx.Admin/Controllers/Organization/EmployeeController.cs
@@ -101,5 +101,18 @@ namespace Fancyx.Admin.Controllers.Organization
             var data = await _employeeService.GetEmployeeInfoAsync(id);
             return Result.Data(data);
         }
+
+        /// <summary>
+        /// 员工列表
+        /// </summary>
+        /// <param name="deptId"></param>
+        /// <returns></returns>
+        [HttpGet("GetDeptEmployeeList")]
+        public async Task<AppResponse<List<EmployeeDto>>> GetEmployeeListAsync(Guid? deptId)
+        {
+            var data = await _employeeService.GetEmployeeListAsync(deptId);
+
+            return Result.Data(data);
+        }
     }
 }

--- a/fancyx-server/Fancyx.Admin/IService/Organization/Dtos/DeptListDto.cs
+++ b/fancyx-server/Fancyx.Admin/IService/Organization/Dtos/DeptListDto.cs
@@ -38,6 +38,11 @@ namespace Fancyx.Admin.IService.Organization.Dtos
         public Guid? CuratorId { get; set; }
 
         /// <summary>
+        /// 负责人姓名
+        /// </summary>
+        public string? CuratorName { get; set; }
+
+        /// <summary>
         /// 邮箱
         /// </summary>
         public string? Email { get; set; }

--- a/fancyx-server/Fancyx.Admin/IService/Organization/IEmployeeService.cs
+++ b/fancyx-server/Fancyx.Admin/IService/Organization/IEmployeeService.cs
@@ -45,5 +45,12 @@ namespace Fancyx.Admin.IService.Organization
         /// <param name="id"></param>
         /// <returns></returns>
         Task<EmployeeInfoDto> GetEmployeeInfoAsync(Guid id);
+
+        /// <summary>
+        /// 获取员工列表
+        /// </summary>
+        /// <param name="deptId"></param>
+        /// <returns></returns>
+        Task<List<EmployeeDto>> GetEmployeeListAsync(Guid? deptId);
     }
 }

--- a/fancyx-server/Fancyx.Admin/IService/System/INotificationService.cs
+++ b/fancyx-server/Fancyx.Admin/IService/System/INotificationService.cs
@@ -1,8 +1,9 @@
 ﻿using Fancyx.Admin.IService.System.Dtos;
+using Fancyx.Core.Interfaces;
 
 namespace Fancyx.Admin.IService.System
 {
-    public interface INotificationService
+    public interface INotificationService : IScopedDependency
     {
         Task AddNotificationAsync(NotificationDto dto);
 

--- a/fancyx-server/Fancyx.Admin/Service/Organization/EmployeeService.cs
+++ b/fancyx-server/Fancyx.Admin/Service/Organization/EmployeeService.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-
 using Fancyx.Admin.Entities.Organization;
 using Fancyx.Admin.Entities.System;
 using Fancyx.Admin.IService.Organization;
@@ -115,6 +114,13 @@ namespace Fancyx.Admin.Service.Organization
                 });
 
             return new PagedResult<EmployeeListDto>(dto) { Items = list, TotalCount = total };
+        }
+
+        public async Task<List<EmployeeDto>> GetEmployeeListAsync(Guid? deptId)
+        {
+            return await _employeeRepository.Where(x => x.Status == 1)
+                .WhereIf(deptId != null, x => x.DeptId == deptId)
+                .ToListAsync<EmployeeDto>();
         }
 
         public async Task<bool> UpdateEmployeeAsync(EmployeeDto dto)

--- a/fancyx-web/src/api/organization/dept.ts
+++ b/fancyx-web/src/api/organization/dept.ts
@@ -61,6 +61,7 @@ export interface DeptListDto {
   description: string | null;
   status: number;
   curatorId: string | null;
+  curatorName: string | null;
   email: string | null;
   phone: string | null;
   parentId: string | null;

--- a/fancyx-web/src/api/organization/employee.ts
+++ b/fancyx-web/src/api/organization/employee.ts
@@ -20,6 +20,16 @@ export function getEmployeeList(dto: EmployeeQueryDto) {
 }
 
 /**
+ * 员工列表
+ * @param dto
+ */
+export function getDeptEmployeeList(deptId?: string) {
+  return httpClient.get<string, AppResponse<EmployeeDto[]>>('/api/employee/GetDeptEmployeeList', {
+    params: deptId,
+  });
+}
+
+/**
  * 修改员工
  * @param dto
  */

--- a/fancyx-web/src/pages/org/dept.tsx
+++ b/fancyx-web/src/pages/org/dept.tsx
@@ -31,7 +31,7 @@ const DepartmentList: React.FC = () => {
     },
     {
       title: '负责人',
-      dataIndex: 'email',
+      dataIndex: 'curatorName',
     },
     {
       title: '操作',


### PR DESCRIPTION
feat:后端，DeptListDto 增加CuratorName属性，GetDeptListAsync方法增加获取部门负责人姓名。
feat:后端，EmployeeService 重载GetEmployeeListAsync方法，通过部门Id获取部门员工。 
feat:前端，部门管理新增和编辑弹窗，增加部门负责人选择下拉。
fix:前端，部门管理列表，修改部门负责人姓名字段属性。